### PR TITLE
Add timeout to identity claim

### DIFF
--- a/packages/auth/src/connection/Connection.ts
+++ b/packages/auth/src/connection/Connection.ts
@@ -541,6 +541,7 @@ export class Connection extends EventEmitter<ConnectionEvents> {
           // Don't respond to a request for an identity claim if we've already sent one
           always: { guard: 'bothSentIdentityClaim', target: 'authenticating' },
           on: { CLAIM_IDENTITY: { actions: 'receiveIdentityClaim' } },
+          ...timeout,
         },
 
         // To authenticate, each peer either presents an invitation (as a new device or as a new


### PR DESCRIPTION
This lets us automatically disconnect from peers who do not start an auth connection with us by timing out at that first stage of connection.