### PR TITLE
fix: Skip assigning member role on connection when user doesn't have role but does have role marker

### DIFF
--- a/packages/auth/src/connection/Connection.ts
+++ b/packages/auth/src/connection/Connection.ts
@@ -327,7 +327,6 @@ export class Connection extends EventEmitter<ConnectionEvents> {
 
           const hasMemberMarker = team.memberHasRoleMarker(userId, MEMBER)
           const hasMemberRole = team.memberHasRole(userId, MEMBER)
-          this.logger.debug('has member role?', hasMemberMarker, hasMemberRole, roles)
           if (!hasMemberRole && (hasMemberMarker || roles.includes(MEMBER))) {
             this.logger.warn(`Peer had marker for ${MEMBER} but lacked the appropriate lockboxes, this may be malicious or we are missing syncable data`)
           } else if (!hasMemberRole && !roles.includes(MEMBER) && context.server == null && !team.hasServer(userId)) {

--- a/packages/auth/src/connection/Connection.ts
+++ b/packages/auth/src/connection/Connection.ts
@@ -325,9 +325,16 @@ export class Connection extends EventEmitter<ConnectionEvents> {
           assert(roles)
           assert(userId)
 
-          if (!roles!.includes(MEMBER) && context.server == null && !team!.hasServer(userId!)) {
-            team!.addMemberRole(userId!, MEMBER)
+          const hasMemberMarker = team.memberHasRoleMarker(userId, MEMBER)
+          const hasMemberRole = team.memberHasRole(userId, MEMBER)
+          this.logger.debug('has member role?', hasMemberMarker, hasMemberRole, roles)
+          if (!hasMemberRole && (hasMemberMarker || roles.includes(MEMBER))) {
+            this.logger.warn(`Peer had marker for ${MEMBER} but lacked the appropriate lockboxes, this may be malicious or we are missing syncable data`)
+          } else if (!hasMemberRole && !roles.includes(MEMBER) && context.server == null && !team.hasServer(userId)) {
+            this.logger.debug(`Assigning ${MEMBER} role to peer`)
+            team.addMemberRole(userId, MEMBER)
           }
+
           this.#queueMessage('ACCEPT_IDENTITY')
         },
 

--- a/packages/auth/src/connection/test/authentication.test.ts
+++ b/packages/auth/src/connection/test/authentication.test.ts
@@ -31,6 +31,36 @@ describe('connection', () => {
         await disconnect(alice, bob)
       })
 
+      it('connects two members and assigns member role', async () => {
+        const { alice, bob } = setup('alice', { user: 'bob', admin: false, member: false, addToTeam: true })
+
+        // 👩🏾 👨🏻‍🦲 Alice and Bob both join the channel
+        await connect(alice, bob)
+
+        // 👩🏾 👨🏻‍🦲 Alice and Bob both leave the channel
+        await disconnect(alice, bob)
+
+        expect(alice.team.memberHasRole(bob.userId, MEMBER)).toBe(true)
+        expect(bob.team.memberHasRole(bob.userId, MEMBER)).toBe(true)
+      })
+
+      it(`connects two members and doesn't assign member role when marker exists but no lockboxes`, async () => {
+        const { alice, bob } = setup('alice', { user: 'bob', admin: false, member: false, rolesWithoutLockboxes: [MEMBER] })
+        expect(alice.team.memberHasRole(bob.userId, MEMBER)).toBe(false)
+        expect(bob.team.memberHasRole(bob.userId, MEMBER)).toBe(false)
+        expect(alice.team.memberHasRoleMarker(bob.userId, MEMBER)).toBe(true)
+        expect(bob.team.memberHasRoleMarker(bob.userId, MEMBER)).toBe(true)
+
+        // 👩🏾 👨🏻‍🦲 Alice and Bob both join the channel
+        await connect(alice, bob)
+
+        // 👩🏾 👨🏻‍🦲 Alice and Bob both leave the channel
+        await disconnect(alice, bob)
+
+        expect(alice.team.memberHasRole(bob.userId, MEMBER)).toBe(false)
+        expect(bob.team.memberHasRole(bob.userId, MEMBER)).toBe(false)
+      })
+
       it("doesn't connect with a member who has been removed", async () => {
         const { alice, bob } = setup('alice', 'bob')
 


### PR DESCRIPTION
* Add check when assigning `member` role on identity acceptance for both the role marker and role membership and log when those don't match
* Add unit tests for `member` role assignment on connections